### PR TITLE
Fix module doc example

### DIFF
--- a/lib/telemetry_metrics_logger.ex
+++ b/lib/telemetry_metrics_logger.ex
@@ -14,7 +14,7 @@ defmodule TelemetryMetricsLogger do
 
   A this reporter can be started as a child of your supervision tree like this:
 
-      {TelemetryMetricsLogger, metrics: metrics, interval: 60}
+      {TelemetryMetricsLogger, metrics: metrics, reporter_options: [interval: 60]}
 
   Then, every sixty seconds, you will see a report like this:
 

--- a/test/telemetry_metrics_logger_test.exs
+++ b/test/telemetry_metrics_logger_test.exs
@@ -11,7 +11,9 @@ defmodule TelemetryMetricsLoggerTest do
           Telemetry.Metrics.sum("http.request.stop.duration", unit: {:native, :microsecond}),
           Telemetry.Metrics.last_value("http.request.stop.duration", unit: {:native, :microsecond}),
           Telemetry.Metrics.summary("http.request.stop.duration", unit: {:native, :microsecond}),
-          Telemetry.Metrics.distribution("http.request.stop.duration", unit: {:native, :microsecond})
+          Telemetry.Metrics.distribution("http.request.stop.duration",
+            unit: {:native, :microsecond}
+          )
         ]
       },
       report: %{
@@ -28,19 +30,21 @@ defmodule TelemetryMetricsLoggerTest do
     report = TelemetryMetricsLogger.build_report(state, ~U[2020-11-15 19:25:17.259000Z])
     Logger.info(report)
 
-    assert report == """
-    Telemetry report 2020-11-15 19:25:17.259000Z:
-      Event [:http, :request, :stop]
-        Measurement "duration"
-          Counter: 6
-          Sum: 31415 μs
-          Last value: 42 μs
-          Summary:
-            Average: 18 μs
-            Max: 42 μs
-            Min: 4 μs
-          Distribution:
-            mean: 18.0 μs
-    """ |> String.trim_trailing()
+    assert report ==
+             """
+             Telemetry report 2020-11-15 19:25:17.259000Z:
+               Event [:http, :request, :stop]
+                 Measurement "duration"
+                   Counter: 6
+                   Sum: 31415 μs
+                   Last value: 42 μs
+                   Summary:
+                     Average: 18 μs
+                     Max: 42 μs
+                     Min: 4 μs
+                   Distribution:
+                     mean: 18.0 μs
+             """
+             |> String.trim_trailing()
   end
 end


### PR DESCRIPTION
The `:interval` option is passed via the `:reporter_options` keywords list.

Also used the opportunity to apply `mix.format` to all files, making contributions easier for people that have it configured in their editor.